### PR TITLE
Fixed mistyped imports

### DIFF
--- a/api/candidates/tests/test_views.py
+++ b/api/candidates/tests/test_views.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from mongoengine.errors import NotUniqueError
 
-from candidates.models import Candidates
+from models import Candidates
 
 
 @pytest.fixture

--- a/api/candidates/views.py
+++ b/api/candidates/views.py
@@ -4,7 +4,7 @@ from restless.dj import DjangoResource
 from restless.preparers import FieldsPreparer
 from restless.serializers import JSONSerializer
 
-from .models import Candidates
+from models.candidates import Candidates
 
 
 class CandidateResource(DjangoResource):


### PR DESCRIPTION
As commented on issue #11, there was misspelling at  and `api/candidates/tests/test_views.py` and `api/candidates/views.py`. That is just a simple fix for those comments.